### PR TITLE
fix: highlight being overwritten if already defined

### DIFF
--- a/plugin/smoothcursor.lua
+++ b/plugin/smoothcursor.lua
@@ -7,7 +7,7 @@ end, {})
 vim.api.nvim_create_user_command('SmoothCursorDeleteSigns', require("smoothcursor.utils").smoothcursor_delete_signs, {})
 
 vim.api.nvim_create_namespace('SmoothCursor')
-vim.api.nvim_set_hl(0, 'SmoothCursor', { bg = nil, fg = "#FFD400" })
+vim.api.nvim_set_hl(0, 'SmoothCursor', { bg = nil, fg = "#FFD400", default = true })
 
 vim.api.nvim_create_namespace('SmoothCursorWhite')
 vim.api.nvim_create_namespace('SmoothCursorRed')


### PR DESCRIPTION
Hi, thanks for the nice plugin!

If the highlight already existed, it was overwritten.