### PR TITLE
Add remember last cursor position indicators & jump functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ require('smoothcursor').setup({
     disable_float_win = false,  -- Disable in floating windows
     enabled_filetypes = nil,    -- Enable only for specific file types, e.g., { "lua", "vim" }
     disabled_filetypes = nil,   -- Disable for these file types, ignored if enabled_filetypes is set. e.g., { "TelescopePrompt", "NvimTree" }
+    -- Show the position of the latest input mode positions. 
+    -- A value of "enter" means the position will be updated when entering the mode.
+    -- A value of "leave" means the position will be updated when leaving the mode.
+    -- `nil` = disabled
+    show_last_positions = nil,  
 })
 ```
 
@@ -119,6 +124,7 @@ https://github.com/gen740/SmoothCursor.nvim/assets/54583542/ba3f90b1-e9ff-4729-b
 | :SmoothCursorFancyOn           | Turn on fancy mode                               |
 | :SmoothCursorFancyOff          | Turn off fancy mode                              |
 | :SmoothCursorDeleteSigns       | Delete all signs if exist                        |
+| :SmoothCursorJump <mode>       | Jump to the given <mode>'s last position         |
 
 ## FAQs
 
@@ -154,4 +160,20 @@ autocmd({ 'ModeChanged' }, {
 ```
 
 https://user-images.githubusercontent.com/54583542/220056425-a7698013-7173-4247-9d40-d468b24df47a.mov
+
+
+### How do I add icons (signs) for mode's last positions?
+
+You can decide which modes should be added. 
+Define the `smoothcursor_<mode>` sign group and set your icon.
+Each `<mode>` is a lowercase letter, e.g., `n` for normal mode, `i` for insert mode, etc.
+
+**example**
+```lua
+vim.fn.sign_define('smoothcursor_v', { text = ' ' })
+vim.fn.sign_define('smoothcursor_V', { text = '' })
+vim.fn.sign_define('smoothcursor_i', { text = '' })
+vim.fn.sign_define('smoothcursor_�', { text = '' })
+vim.fn.sign_define('smoothcursor_R', { text = '󰊄' })
+```
 

--- a/lua/smoothcursor/callbacks/default.lua
+++ b/lua/smoothcursor/callbacks/default.lua
@@ -2,9 +2,8 @@ local callback = require('smoothcursor.callbacks')
 local buffer = callback.buffer
 
 local config = require('smoothcursor.config')
+local last_positions = require'smoothcursor.last_positions'
 local debug_callback = require('smoothcursor.debug').debug_callback
-
-local last_positions = {}
 
 -- Default cursor callback. buffer["prev"] is always integer
 local function sc_default()
@@ -65,10 +64,11 @@ local function sc_default()
       callback.place_sign(buffer['prev'], 'smoothcursor')
 
       local current_buf = vim.api.nvim_get_current_buf()
-      for name, line in pairs(last_positions[tostring(current_buf)] or {}) do
-        if line ~= nil then
-          callback.place_sign(line, 'smoothcursor_' .. name)
-        end
+
+      for name, pos in pairs(last_positions.get_positions(current_buf)) do
+        local line = pos[1]
+
+        callback.place_sign(line, 'smoothcursor_' .. name)
       end
     end
 

--- a/lua/smoothcursor/callbacks/default.lua
+++ b/lua/smoothcursor/callbacks/default.lua
@@ -4,11 +4,16 @@ local buffer = callback.buffer
 local config = require('smoothcursor.config')
 local debug_callback = require('smoothcursor.debug').debug_callback
 
--- Default corsor callback. buffer["prev"] is always integer
+local last_positions = {
+    insert = nil,
+}
+
+-- Default cursor callback. buffer["prev"] is always integer
 local function sc_default()
   if not callback.is_enabled() then
     return
   end
+
   buffer['.'] = vim.fn.line('.')
   if buffer['prev'] == nil then
     buffer['prev'] = buffer['.']
@@ -17,6 +22,7 @@ local function sc_default()
   buffer['diff'] = math.min(buffer['diff'], vim.fn.winheight(0) * 2)
   buffer['w0'] = vim.fn.line('w0')
   buffer['w$'] = vim.fn.line('w$')
+  
   if math.abs(buffer['diff']) > config.value.threshold then
     local counter = 1
     callback.sc_timer:post(function()
@@ -54,14 +60,24 @@ local function sc_default()
   else
     buffer['prev'] = buffer['.']
     buffer:all(buffer['.'])
+
     callback.unplace_signs()
+
     if callback.fancy_head_exists() then
       callback.place_sign(buffer['prev'], 'smoothcursor')
     end
+
+    for name, line in pairs(last_positions) do
+      if line ~= nil then
+        callback.place_sign(line, 'smoothcursor_' .. name)
+      end
+    end
+
     debug_callback(buffer, { 'Jump: False' })
   end
 end
 
 return {
   sc_default = sc_default,
+  last_positions = last_positions,
 }

--- a/lua/smoothcursor/callbacks/default.lua
+++ b/lua/smoothcursor/callbacks/default.lua
@@ -2,7 +2,7 @@ local callback = require('smoothcursor.callbacks')
 local buffer = callback.buffer
 
 local config = require('smoothcursor.config')
-local last_positions = require'smoothcursor.last_positions'
+local last_positions = require('smoothcursor.last_positions')
 local debug_callback = require('smoothcursor.debug').debug_callback
 
 -- Default cursor callback. buffer["prev"] is always integer
@@ -78,5 +78,4 @@ end
 
 return {
   sc_default = sc_default,
-  last_positions = last_positions,
 }

--- a/lua/smoothcursor/callbacks/default.lua
+++ b/lua/smoothcursor/callbacks/default.lua
@@ -63,11 +63,12 @@ local function sc_default()
 
     if callback.fancy_head_exists() then
       callback.place_sign(buffer['prev'], 'smoothcursor')
-    end
 
-    for name, line in pairs(last_positions) do
-      if line ~= nil then
-        callback.place_sign(line, 'smoothcursor_' .. name)
+      local current_buf = vim.api.nvim_get_current_buf()
+      for name, line in pairs(last_positions[tostring(current_buf)] or {}) do
+        if line ~= nil then
+          callback.place_sign(line, 'smoothcursor_' .. name)
+        end
       end
     end
 

--- a/lua/smoothcursor/callbacks/default.lua
+++ b/lua/smoothcursor/callbacks/default.lua
@@ -4,9 +4,7 @@ local buffer = callback.buffer
 local config = require('smoothcursor.config')
 local debug_callback = require('smoothcursor.debug').debug_callback
 
-local last_positions = {
-    insert = nil,
-}
+local last_positions = {}
 
 -- Default cursor callback. buffer["prev"] is always integer
 local function sc_default()
@@ -22,7 +20,7 @@ local function sc_default()
   buffer['diff'] = math.min(buffer['diff'], vim.fn.winheight(0) * 2)
   buffer['w0'] = vim.fn.line('w0')
   buffer['w$'] = vim.fn.line('w$')
-  
+
   if math.abs(buffer['diff']) > config.value.threshold then
     local counter = 1
     callback.sc_timer:post(function()

--- a/lua/smoothcursor/callbacks/init.lua
+++ b/lua/smoothcursor/callbacks/init.lua
@@ -32,13 +32,10 @@ local function unplace_signs(with_timer_stop)
     sc_timer:abort()
   end
 
-  vim.fn.sign_unplace(
-    '*',
-    {
-      buffer = vim.fn.bufname(),
-      id = config.value.cursorID
-    }
-  )
+  vim.fn.sign_unplace('*', {
+    buffer = vim.fn.bufname(),
+    id = config.value.cursorID,
+  })
 
   sc_debug.unplace_signs_conuter = sc_debug.unplace_signs_conuter + 1
 end

--- a/lua/smoothcursor/callbacks/init.lua
+++ b/lua/smoothcursor/callbacks/init.lua
@@ -21,7 +21,6 @@ local function buffer_set_all(value)
   buffer['prev'] = value
   buffer:all(value)
 
-  cc
   sc_debug.debug_callback(buffer, { 'Buffer Reset' }, function()
     sc_debug.reset_counter = sc_debug.reset_counter + 1
   end)

--- a/lua/smoothcursor/callbacks/init.lua
+++ b/lua/smoothcursor/callbacks/init.lua
@@ -21,7 +21,7 @@ local function buffer_set_all(value)
   buffer['prev'] = value
   buffer:all(value)
 
-  -- Debug
+  cc
   sc_debug.debug_callback(buffer, { 'Buffer Reset' }, function()
     sc_debug.reset_counter = sc_debug.reset_counter + 1
   end)
@@ -32,7 +32,15 @@ local function unplace_signs(with_timer_stop)
   if with_timer_stop == true then
     sc_timer:abort()
   end
-  vim.fn.sign_unplace('*', { buffer = vim.fn.bufname(), id = config.value.cursorID })
+
+  vim.fn.sign_unplace(
+      '*',
+      {
+          buffer = vim.fn.bufname(),
+          id = config.value.cursorID
+      }
+  )
+
   sc_debug.unplace_signs_conuter = sc_debug.unplace_signs_conuter + 1
 end
 

--- a/lua/smoothcursor/callbacks/init.lua
+++ b/lua/smoothcursor/callbacks/init.lua
@@ -52,7 +52,11 @@ local function place_sign(position, name, priority)
   if position < buffer['w0'] or position > buffer['w$'] then
     return
   end
-  if name ~= nil then
+
+  -- if len == 0, then sign is undefined
+  local is_sign_defined = #vim.fn.sign_getdefined(name) > 0
+
+  if is_sign_defined and name ~= nil then
     vim.fn.sign_place(
       config.value.cursorID,
       'SmoothCursor',

--- a/lua/smoothcursor/callbacks/init.lua
+++ b/lua/smoothcursor/callbacks/init.lua
@@ -33,11 +33,11 @@ local function unplace_signs(with_timer_stop)
   end
 
   vim.fn.sign_unplace(
-      '*',
-      {
-          buffer = vim.fn.bufname(),
-          id = config.value.cursorID
-      }
+    '*',
+    {
+      buffer = vim.fn.bufname(),
+      id = config.value.cursorID
+    }
   )
 
   sc_debug.unplace_signs_conuter = sc_debug.unplace_signs_conuter + 1

--- a/lua/smoothcursor/config.lua
+++ b/lua/smoothcursor/config.lua
@@ -61,6 +61,6 @@ return {
     disable_float_win = false,
     disabled_filetypes = nil,
     enabled_filetypes = nil,
-    show_last_positions = "leave",
+    show_last_positions = 'leave',
   },
 }

--- a/lua/smoothcursor/config.lua
+++ b/lua/smoothcursor/config.lua
@@ -61,6 +61,6 @@ return {
     disable_float_win = false,
     disabled_filetypes = nil,
     enabled_filetypes = nil,
-    show_last_positions = true,
+    show_last_positions = "leave",
   },
 }

--- a/lua/smoothcursor/config.lua
+++ b/lua/smoothcursor/config.lua
@@ -61,5 +61,6 @@ return {
     disable_float_win = false,
     disabled_filetypes = nil,
     enabled_filetypes = nil,
+    show_last_positions = true,
   },
 }

--- a/lua/smoothcursor/init.lua
+++ b/lua/smoothcursor/init.lua
@@ -179,7 +179,4 @@ end
 return {
   setup = setup,
   init_and_start = init_and_start,
-  get_last_positions = function()
-    return require'smoothcursor.callbacks.default'.last_positions
-  end,
 }

--- a/lua/smoothcursor/init.lua
+++ b/lua/smoothcursor/init.lua
@@ -172,4 +172,7 @@ end
 return {
   setup = setup,
   init_and_start = init_and_start,
+  get_last_positions = function()
+    return require'smoothcursor.callbacks.default'.last_positions
+  end,
 }

--- a/lua/smoothcursor/init.lua
+++ b/lua/smoothcursor/init.lua
@@ -58,6 +58,7 @@ local config = require('smoothcursor.config')
 ---@field disable_float_win boolean
 ---@field disabled_filetypes string[]|nil
 ---@field enabled_filetypes string[]|nil
+---@field show_last_positions boolean
 
 
 -- local function define_signs(name, cursor, texthl,  )

--- a/lua/smoothcursor/init.lua
+++ b/lua/smoothcursor/init.lua
@@ -60,6 +60,13 @@ local config = require('smoothcursor.config')
 ---@field enabled_filetypes string[]|nil
 ---@field show_last_positions string|nil -- "enter" | "leave"
 
+-- Used for debugging, doesn't contain all the actual fields.
+-- More meant to be used as an example.
+---@class LastPositionsInfo
+---@field i number[]
+---@field n number[]
+---@field V number[]
+---@field v number[]
 
 -- local function define_signs(name, cursor, texthl,  )
 

--- a/lua/smoothcursor/init.lua
+++ b/lua/smoothcursor/init.lua
@@ -58,7 +58,7 @@ local config = require('smoothcursor.config')
 ---@field disable_float_win boolean
 ---@field disabled_filetypes string[]|nil
 ---@field enabled_filetypes string[]|nil
----@field show_last_positions boolean
+---@field show_last_positions string|nil -- "enter" | "leave"
 
 
 -- local function define_signs(name, cursor, texthl,  )

--- a/lua/smoothcursor/last_positions.lua
+++ b/lua/smoothcursor/last_positions.lua
@@ -1,0 +1,48 @@
+local last_positions = {}
+
+---Format a buffer for saving it
+---@param buffer number
+---@return string
+local function format_buf(buffer)
+    return tostring(buffer)
+end
+
+---Set the last position of the cursor for a buffer
+---@param buffer number
+---@param mode string
+---@param pos number[]
+local function set_position(buffer, mode, pos)
+    if last_positions[format_buf(buffer)] == nil then
+        return
+    end
+
+    last_positions[format_buf(buffer)][mode] = pos
+end
+
+---Get the last positions for a buffer.
+---Returns an empty table if the buffer is not found.
+---@param buffer number
+---@return LastPositionsInfo
+local function get_positions(buffer)
+    return last_positions[format_buf(buffer)] or {}
+end
+
+---Register a buffer to be tracked
+---We explicitly register buffers to avoid tracking buffers that shouldn't save
+---last positions (such as floating windows for example).
+---@param buffer any
+local function register_buffer(buffer)
+    last_positions[format_buf(buffer)] = {}
+end
+
+local function unregister_buffer(buffer)
+    last_positions[format_buf(buffer)] = nil
+end
+
+return {
+    last_positions = last_positions,
+    set_position = set_position,
+    get_positions = get_positions,
+    register_buffer = register_buffer,
+    unregister_buffer = unregister_buffer,
+}

--- a/lua/smoothcursor/last_positions.lua
+++ b/lua/smoothcursor/last_positions.lua
@@ -13,7 +13,7 @@ end
 ---@param pos number[]
 local function set_position(buffer, mode, pos)
   if last_positions[format_buf(buffer)] == nil then
-      return
+    return
   end
 
   last_positions[format_buf(buffer)][mode] = pos

--- a/lua/smoothcursor/last_positions.lua
+++ b/lua/smoothcursor/last_positions.lua
@@ -4,7 +4,7 @@ local last_positions = {}
 ---@param buffer number
 ---@return string
 local function format_buf(buffer)
-    return tostring(buffer)
+  return tostring(buffer)
 end
 
 ---Set the last position of the cursor for a buffer
@@ -12,11 +12,11 @@ end
 ---@param mode string
 ---@param pos number[]
 local function set_position(buffer, mode, pos)
-    if last_positions[format_buf(buffer)] == nil then
-        return
-    end
+  if last_positions[format_buf(buffer)] == nil then
+      return
+  end
 
-    last_positions[format_buf(buffer)][mode] = pos
+  last_positions[format_buf(buffer)][mode] = pos
 end
 
 ---Get the last positions for a buffer.
@@ -24,7 +24,7 @@ end
 ---@param buffer number
 ---@return LastPositionsInfo
 local function get_positions(buffer)
-    return last_positions[format_buf(buffer)] or {}
+  return last_positions[format_buf(buffer)] or {}
 end
 
 ---Register a buffer to be tracked
@@ -32,17 +32,17 @@ end
 ---last positions (such as floating windows for example).
 ---@param buffer any
 local function register_buffer(buffer)
-    last_positions[format_buf(buffer)] = {}
+  last_positions[format_buf(buffer)] = {}
 end
 
 local function unregister_buffer(buffer)
-    last_positions[format_buf(buffer)] = nil
+  last_positions[format_buf(buffer)] = nil
 end
 
 return {
-    last_positions = last_positions,
-    set_position = set_position,
-    get_positions = get_positions,
-    register_buffer = register_buffer,
-    unregister_buffer = unregister_buffer,
+  last_positions = last_positions,
+  set_position = set_position,
+  get_positions = get_positions,
+  register_buffer = register_buffer,
+  unregister_buffer = unregister_buffer,
 }

--- a/lua/smoothcursor/utils.lua
+++ b/lua/smoothcursor/utils.lua
@@ -57,7 +57,7 @@ sc.smoothcursor_start = function(init_fire)
 
   if config.value.show_last_positions then
       -- Store last positions
-      vim.api.nvim_create_autocmd({ 'InsertLeavePre' }, {
+      vim.api.nvim_create_autocmd({ 'ModeChanged' }, {
         group = 'SmoothCursor',
         callback = function()
             local insertmode = vim.api.nvim_get_mode().mode

--- a/lua/smoothcursor/utils.lua
+++ b/lua/smoothcursor/utils.lua
@@ -55,14 +55,14 @@ sc.smoothcursor_start = function(init_fire)
     end,
   })
 
-  if config.value.show_last_positions then
+  if config.value.show_last_positions == "enter" then
       -- Store last positions
       vim.api.nvim_create_autocmd({ 'ModeChanged' }, {
         group = 'SmoothCursor',
         callback = function()
-            local insertmode = vim.api.nvim_get_mode().mode
+            local mode = vim.api.nvim_get_mode().mode
 
-            last_positions[insertmode] = vim.api.nvim_win_get_cursor(0)[1]
+            last_positions[mode] = vim.api.nvim_win_get_cursor(0)[1]
         end
       })
       vim.api.nvim_create_autocmd({ 'InsertEnter' }, {
@@ -71,6 +71,18 @@ sc.smoothcursor_start = function(init_fire)
             last_positions.insert = nil
         end
       })
+  elseif config.value.show_last_positions == "leave" then
+    -- Neovim always starts with normal mode, doesn't it?
+    local current_mode = "n"
+
+    vim.api.nvim_create_autocmd({ 'ModeChanged' }, {
+      group = 'SmoothCursor',
+      callback = function()
+            last_positions[current_mode] = vim.api.nvim_win_get_cursor(0)[1]
+
+          current_mode = vim.api.nvim_get_mode().mode
+      end
+    })
   end
 
   smoothcursor_started = true

--- a/lua/smoothcursor/utils.lua
+++ b/lua/smoothcursor/utils.lua
@@ -72,7 +72,7 @@ sc.smoothcursor_start = function(init_fire)
     vim.api.nvim_create_autocmd({ 'BufDelete' }, {
       group = 'SmoothCursor',
       callback = function()
-        local buffer = vim.api.nvim_get_current_buf()
+        local buffer = vim.fn.bufnr('$')
 
         last_positions.unregister_buffer(buffer)
       end

--- a/lua/smoothcursor/utils.lua
+++ b/lua/smoothcursor/utils.lua
@@ -3,7 +3,7 @@ local smoothcursor_started = false
 local callback = require('smoothcursor.callbacks')
 local config = require('smoothcursor.config')
 local init = require('smoothcursor.init')
-local last_positions = require'smoothcursor.last_positions'
+local last_positions = require('smoothcursor.last_positions')
 local buffer_leaved = false
 
 --@param init_fire boolean
@@ -61,15 +61,15 @@ sc.smoothcursor_start = function(init_fire)
     -- Please note that casting the buffer numbers to strings is necessary, otherwise
     -- lua will interpret the buffer numbers as array indices
     -- Add / Remove buffers to `last_positions` table
-    vim.api.nvim_create_autocmd({ "BufAdd" }, {
+    vim.api.nvim_create_autocmd({ 'BufAdd' }, {
       group = 'SmoothCursor',
       callback = function()
-        local buffer = vim.fn.bufnr("$")
+        local buffer = vim.fn.bufnr('$')
 
         last_positions.register_buffer(buffer)
       end
     })
-    vim.api.nvim_create_autocmd({ "BufDelete" }, {
+    vim.api.nvim_create_autocmd({ 'BufDelete' }, {
       group = 'SmoothCursor',
       callback = function()
         local buffer = vim.api.nvim_get_current_buf()
@@ -88,7 +88,7 @@ sc.smoothcursor_start = function(init_fire)
     })
 
     -- Neovim always starts with normal mode, doesn't it?
-    local current_mode = "n"
+    local current_mode = 'n'
 
     vim.api.nvim_create_autocmd({ 'ModeChanged' }, {
       group = 'SmoothCursor',
@@ -101,7 +101,7 @@ sc.smoothcursor_start = function(init_fire)
         -- if is nil, the current buffer is not a text file (could be floating window for example)
         -- we don't want to set the last position in this case
         if last_pos ~= nil then
-          if last_pos_config == "enter" then
+          if last_pos_config == 'enter' then
             last_positions.set_position(
               buffer,
               mode,

--- a/lua/smoothcursor/utils.lua
+++ b/lua/smoothcursor/utils.lua
@@ -67,7 +67,7 @@ sc.smoothcursor_start = function(init_fire)
         local buffer = vim.fn.bufnr('$')
 
         last_positions.register_buffer(buffer)
-      end
+      end,
     })
     vim.api.nvim_create_autocmd({ 'BufDelete' }, {
       group = 'SmoothCursor',
@@ -75,7 +75,7 @@ sc.smoothcursor_start = function(init_fire)
         local buffer = vim.fn.bufnr('$')
 
         last_positions.unregister_buffer(buffer)
-      end
+      end,
     })
     -- If starting into a buffer, the BufEnter event is not fired, but `VimEnter` is.
     vim.api.nvim_create_autocmd({ 'VimEnter' }, {
@@ -84,7 +84,7 @@ sc.smoothcursor_start = function(init_fire)
         local buffer = vim.api.nvim_get_current_buf()
 
         last_positions.register_buffer(buffer)
-      end
+      end,
     })
 
     -- Neovim always starts with normal mode, doesn't it?
@@ -102,22 +102,14 @@ sc.smoothcursor_start = function(init_fire)
         -- we don't want to set the last position in this case
         if last_pos ~= nil then
           if last_pos_config == 'enter' then
-            last_positions.set_position(
-              buffer,
-              mode,
-              vim.api.nvim_win_get_cursor(0)
-            )
+            last_positions.set_position(buffer, mode, vim.api.nvim_win_get_cursor(0))
           else
-            last_positions.set_position(
-              buffer,
-              current_mode,
-              vim.api.nvim_win_get_cursor(0)
-            )
+            last_positions.set_position(buffer, current_mode, vim.api.nvim_win_get_cursor(0))
 
             current_mode = vim.api.nvim_get_mode().mode
           end
         end
-      end
+      end,
     })
   end
 

--- a/lua/smoothcursor/utils.lua
+++ b/lua/smoothcursor/utils.lua
@@ -3,6 +3,7 @@ local smoothcursor_started = false
 local callback = require('smoothcursor.callbacks')
 local config = require('smoothcursor.config')
 local init = require('smoothcursor.init')
+local last_positions = require("smoothcursor.callbacks.default").last_positions
 local buffer_leaved = false
 
 --@param init_fire boolean
@@ -52,6 +53,22 @@ sc.smoothcursor_start = function(init_fire)
         callback.buffer_set_all(0)
       end
     end,
+  })
+
+  -- Store last positions
+  vim.api.nvim_create_autocmd({ 'InsertLeavePre' }, {
+    group = 'SmoothCursor',
+    callback = function()
+        local insertmode = vim.api.nvim_get_mode().mode
+
+        last_positions[insertmode] = vim.api.nvim_win_get_cursor(0)[1]
+    end
+  })
+  vim.api.nvim_create_autocmd({ 'InsertEnter' }, {
+    group = 'SmoothCursor',
+    callback = function()
+        last_positions.insert = nil
+    end
   })
 
   smoothcursor_started = true

--- a/lua/smoothcursor/utils.lua
+++ b/lua/smoothcursor/utils.lua
@@ -55,21 +55,23 @@ sc.smoothcursor_start = function(init_fire)
     end,
   })
 
-  -- Store last positions
-  vim.api.nvim_create_autocmd({ 'InsertLeavePre' }, {
-    group = 'SmoothCursor',
-    callback = function()
-        local insertmode = vim.api.nvim_get_mode().mode
+  if config.value.show_last_positions then
+      -- Store last positions
+      vim.api.nvim_create_autocmd({ 'InsertLeavePre' }, {
+        group = 'SmoothCursor',
+        callback = function()
+            local insertmode = vim.api.nvim_get_mode().mode
 
-        last_positions[insertmode] = vim.api.nvim_win_get_cursor(0)[1]
-    end
-  })
-  vim.api.nvim_create_autocmd({ 'InsertEnter' }, {
-    group = 'SmoothCursor',
-    callback = function()
-        last_positions.insert = nil
-    end
-  })
+            last_positions[insertmode] = vim.api.nvim_win_get_cursor(0)[1]
+        end
+      })
+      vim.api.nvim_create_autocmd({ 'InsertEnter' }, {
+        group = 'SmoothCursor',
+        callback = function()
+            last_positions.insert = nil
+        end
+      })
+  end
 
   smoothcursor_started = true
   if init_fire then

--- a/lua/smoothcursor/utils.lua
+++ b/lua/smoothcursor/utils.lua
@@ -64,24 +64,26 @@ sc.smoothcursor_start = function(init_fire)
     vim.api.nvim_create_autocmd({ "BufAdd" }, {
       group = 'SmoothCursor',
       callback = function()
-          local buffer = vim.fn.bufnr("$")
+        local buffer = vim.fn.bufnr("$")
 
-          last_positions.register_buffer(buffer)
+        last_positions.register_buffer(buffer)
       end
     })
     vim.api.nvim_create_autocmd({ "BufDelete" }, {
       group = 'SmoothCursor',
       callback = function()
-          local buffer = vim.api.nvim_get_current_buf()
-          last_positions.unregister_buffer(buffer)
+        local buffer = vim.api.nvim_get_current_buf()
+
+        last_positions.unregister_buffer(buffer)
       end
     })
     -- If starting into a buffer, the BufEnter event is not fired, but `VimEnter` is.
     vim.api.nvim_create_autocmd({ 'VimEnter' }, {
       group = 'SmoothCursor',
       callback = function()
-          local buffer = vim.api.nvim_get_current_buf()
-          last_positions.register_buffer(buffer)
+        local buffer = vim.api.nvim_get_current_buf()
+
+        last_positions.register_buffer(buffer)
       end
     })
 

--- a/plugin/smoothcursor.lua
+++ b/plugin/smoothcursor.lua
@@ -1,5 +1,6 @@
 -- Define Commands
 local utils = require('smoothcursor.utils')
+local last_positions = require"smoothcursor.callbacks.default".last_positions
 
 vim.api.nvim_create_user_command('SmoothCursorStart', utils.smoothcursor_start, {})
 
@@ -37,3 +38,28 @@ end, {})
 vim.api.nvim_create_user_command('SmoothCursorDeleteSigns', utils.smoothcursor_delete_signs, {})
 
 vim.api.nvim_create_user_command('SmoothCursorDebug', require('smoothcursor.debug').debug, {})
+
+-- Jump to last positions
+vim.api.nvim_create_user_command(
+    'SmoothCursorJump',
+    function(opt)
+        -- Get identifier from 
+        local identifier = opt.fargs[1]
+
+        local last_position = last_positions[identifier]
+
+        if last_position == nil then
+          vim.notify(string.format('No last position for identifier %s', identifier))
+          return
+        end
+
+        -- Jump to last position
+        local current_char = vim.api.nvim_win_get_cursor(0)[2]
+
+        vim.api.nvim_win_set_cursor(0, { last_position, current_char })
+    end,
+    {
+        nargs = 1,
+        desc = 'Jump to last position of identifier <identifier>'
+    }
+)

--- a/plugin/smoothcursor.lua
+++ b/plugin/smoothcursor.lua
@@ -1,6 +1,6 @@
 -- Define Commands
 local utils = require('smoothcursor.utils')
-local last_positions = require"smoothcursor.callbacks.default".last_positions
+local last_positions = require('smoothcursor.last_positions')
 
 vim.api.nvim_create_user_command('SmoothCursorStart', utils.smoothcursor_start, {})
 
@@ -44,11 +44,11 @@ vim.api.nvim_create_user_command('SmoothCursorDebug', require('smoothcursor.debu
 vim.api.nvim_create_user_command(
   'SmoothCursorJump',
   function(opt)
-    -- Get identifier from 
+    -- Get identifier from args
     local identifier = opt.fargs[1]
 
     local buffer = vim.api.nvim_get_current_buf()
-    local last_position = last_positions[buffer][identifier]
+    local last_position = last_positions.get_positions(buffer)[identifier]
 
     if last_position == nil then
       vim.notify(string.format('No last position for identifier %s', identifier))
@@ -56,9 +56,7 @@ vim.api.nvim_create_user_command(
     end
 
     -- Jump to last position
-    local current_char = vim.api.nvim_win_get_cursor(0)[2]
-
-    vim.api.nvim_win_set_cursor(0, { last_position, current_char })
+    vim.api.nvim_win_set_cursor(0, last_position)
   end,
   {
     nargs = 1,

--- a/plugin/smoothcursor.lua
+++ b/plugin/smoothcursor.lua
@@ -41,25 +41,21 @@ vim.api.nvim_create_user_command('SmoothCursorDebug', require('smoothcursor.debu
 
 -- Jump to last positions
 -- TODO: Add autocomplete
-vim.api.nvim_create_user_command(
-  'SmoothCursorJump',
-  function(opt)
-    -- Get identifier from args
-    local identifier = opt.fargs[1]
+vim.api.nvim_create_user_command('SmoothCursorJump', function(opt)
+  -- Get identifier from args
+  local identifier = opt.fargs[1]
 
-    local buffer = vim.api.nvim_get_current_buf()
-    local last_position = last_positions.get_positions(buffer)[identifier]
+  local buffer = vim.api.nvim_get_current_buf()
+  local last_position = last_positions.get_positions(buffer)[identifier]
 
-    if last_position == nil then
-      vim.notify(string.format('No last position for identifier %s', identifier))
-      return
-    end
+  if last_position == nil then
+    vim.notify(string.format('No last position for identifier %s', identifier))
+    return
+  end
 
-    -- Jump to last position
-    vim.api.nvim_win_set_cursor(0, last_position)
-  end,
-  {
-    nargs = 1,
-    desc = 'Jump to last position of identifier <identifier>'
-  }
-)
+  -- Jump to last position
+  vim.api.nvim_win_set_cursor(0, last_position)
+end, {
+  nargs = 1,
+  desc = 'Jump to last position of identifier <identifier>',
+})

--- a/plugin/smoothcursor.lua
+++ b/plugin/smoothcursor.lua
@@ -40,13 +40,15 @@ vim.api.nvim_create_user_command('SmoothCursorDeleteSigns', utils.smoothcursor_d
 vim.api.nvim_create_user_command('SmoothCursorDebug', require('smoothcursor.debug').debug, {})
 
 -- Jump to last positions
+-- TODO: Add autocomplete
 vim.api.nvim_create_user_command(
     'SmoothCursorJump',
     function(opt)
         -- Get identifier from 
         local identifier = opt.fargs[1]
 
-        local last_position = last_positions[identifier]
+        local buffer = vim.api.nvim_get_current_buf()
+        local last_position = last_positions[buffer][identifier]
 
         if last_position == nil then
           vim.notify(string.format('No last position for identifier %s', identifier))

--- a/plugin/smoothcursor.lua
+++ b/plugin/smoothcursor.lua
@@ -42,26 +42,26 @@ vim.api.nvim_create_user_command('SmoothCursorDebug', require('smoothcursor.debu
 -- Jump to last positions
 -- TODO: Add autocomplete
 vim.api.nvim_create_user_command(
-    'SmoothCursorJump',
-    function(opt)
-        -- Get identifier from 
-        local identifier = opt.fargs[1]
+  'SmoothCursorJump',
+  function(opt)
+    -- Get identifier from 
+    local identifier = opt.fargs[1]
 
-        local buffer = vim.api.nvim_get_current_buf()
-        local last_position = last_positions[buffer][identifier]
+    local buffer = vim.api.nvim_get_current_buf()
+    local last_position = last_positions[buffer][identifier]
 
-        if last_position == nil then
-          vim.notify(string.format('No last position for identifier %s', identifier))
-          return
-        end
+    if last_position == nil then
+      vim.notify(string.format('No last position for identifier %s', identifier))
+      return
+    end
 
-        -- Jump to last position
-        local current_char = vim.api.nvim_win_get_cursor(0)[2]
+    -- Jump to last position
+    local current_char = vim.api.nvim_win_get_cursor(0)[2]
 
-        vim.api.nvim_win_set_cursor(0, { last_position, current_char })
-    end,
-    {
-        nargs = 1,
-        desc = 'Jump to last position of identifier <identifier>'
-    }
+    vim.api.nvim_win_set_cursor(0, { last_position, current_char })
+  end,
+  {
+    nargs = 1,
+    desc = 'Jump to last position of identifier <identifier>'
+  }
 )


### PR DESCRIPTION
This PR adds the config `show_last_positions` which will show the last positions for insert / visual / replace mode and also allows the user to jump to it directly.

This is a feature I've wanted for a long time; I first wanted to create a plugin myself but decided it would be better to directly integrate it with SmoothCursor.

You can configure it like this:

```lua
vim.fn.sign_define('smoothcursor_v', { text = '' })
vim.fn.sign_define('smoothcursor_i', { text = '' })
```


**This PR is not ready yet. Some things do not yet such as any mode except for insert mode being shown - I don't know why this is the case, but I'll need to figure that out first**