### PR TITLE
Remove cursorID setting.

### DIFF
--- a/lua/smoothcursor/callbacks/init.lua
+++ b/lua/smoothcursor/callbacks/init.lua
@@ -32,7 +32,7 @@ local function unplace_signs(with_timer_stop)
   if with_timer_stop == true then
     sc_timer:abort()
   end
-  vim.fn.sign_unplace('*', { buffer = vim.fn.bufname(), id = config.value.cursorID })
+  vim.fn.sign_unplace('SmoothCursor', { buffer = vim.fn.bufname() })
   sc_debug.unplace_signs_conuter = sc_debug.unplace_signs_conuter + 1
 end
 
@@ -47,7 +47,7 @@ local function place_sign(position, name, priority)
   end
   if name ~= nil then
     vim.fn.sign_place(
-      config.value.cursorID,
+      0,
       'SmoothCursor',
       name,
       vim.fn.bufname(),

--- a/lua/smoothcursor/config.lua
+++ b/lua/smoothcursor/config.lua
@@ -50,7 +50,6 @@ return {
 
     always_redraw = true,
     flyin_effect = nil,
-    cursorID = 23874823,
     intervals = 35,
     timeout = 3000,
     type = 'default',

--- a/lua/smoothcursor/init.lua
+++ b/lua/smoothcursor/init.lua
@@ -47,7 +47,6 @@ local config = require('smoothcursor.config')
 ---@field flyin_effect string|nil
 ---@field fancy FancyConfig
 ---@field matrix MatrixConfig
----@field cursorID integer
 ---@field intervals integer
 ---@field timeout integer
 ---@field type string
@@ -58,7 +57,6 @@ local config = require('smoothcursor.config')
 ---@field disable_float_win boolean
 ---@field disabled_filetypes string[]|nil
 ---@field enabled_filetypes string[]|nil
-
 
 -- local function define_signs(name, cursor, texthl,  )
 


### PR DESCRIPTION
Since the sign-identifier must be unique for each sign, remove the cursorID setting and assign 0 as the default value for the sign-identifier.