### PR TITLE
Add max_threshold setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ require('smoothcursor').setup({
     priority = 10,              -- Set marker priority
     timeout = 3000,             -- Timeout for animations in milliseconds
     threshold = 3,              -- Animate only if cursor moves more than this many lines
+    max_threshold = 500         -- If you move more than this many lines, don't animate
     disable_float_win = false,  -- Disable in floating windows
     enabled_filetypes = nil,    -- Enable only for specific file types, e.g., { "lua", "vim" }
     disabled_filetypes = nil,   -- Disable for these file types, ignored if enabled_filetypes is set. e.g., { "TelescopePrompt", "NvimTree" }

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ require('smoothcursor').setup({
     priority = 10,              -- Set marker priority
     timeout = 3000,             -- Timeout for animations in milliseconds
     threshold = 3,              -- Animate only if cursor moves more than this many lines
-    max_threshold = 500         -- If you move more than this many lines, don't animate
+    max_threshold = nil         -- If you move more than this many lines, don't animate (if `nil`, deactivate check)
     disable_float_win = false,  -- Disable in floating windows
     enabled_filetypes = nil,    -- Enable only for specific file types, e.g., { "lua", "vim" }
     disabled_filetypes = nil,   -- Disable for these file types, ignored if enabled_filetypes is set. e.g., { "TelescopePrompt", "NvimTree" }

--- a/doc/smoothcursor.txt
+++ b/doc/smoothcursor.txt
@@ -80,6 +80,7 @@ setup({opts})
             priority = 10,              -- Set marker priority
             timeout = 3000,             -- Timeout for animations in milliseconds
             threshold = 3,              -- Animate only if cursor moves more than this many lines
+	    max_threshold = 500         -- If you move more than this many lines, don't animate
             disable_float_win = false,  -- Disable in floating windows
             enabled_filetypes = nil,    -- Enable only for specific file types, e.g., { "lua", "vim" }
             disabled_filetypes = nil,   -- Disable for these file types, ignored if enabled_filetypes is set. e.g., { "TelescopePrompt", "NvimTree" }

--- a/doc/smoothcursor.txt
+++ b/doc/smoothcursor.txt
@@ -80,7 +80,7 @@ setup({opts})
             priority = 10,              -- Set marker priority
             timeout = 3000,             -- Timeout for animations in milliseconds
             threshold = 3,              -- Animate only if cursor moves more than this many lines
-            max_threshold = 500         -- If you move more than this many lines, don't animate
+            max_threshold = nil         -- If you move more than this many lines, don't animate (if `nil`, deactivate check)
             disable_float_win = false,  -- Disable in floating windows
             enabled_filetypes = nil,    -- Enable only for specific file types, e.g., { "lua", "vim" }
             disabled_filetypes = nil,   -- Disable for these file types, ignored if enabled_filetypes is set. e.g., { "TelescopePrompt", "NvimTree" }

--- a/doc/smoothcursor.txt
+++ b/doc/smoothcursor.txt
@@ -80,7 +80,7 @@ setup({opts})
             priority = 10,              -- Set marker priority
             timeout = 3000,             -- Timeout for animations in milliseconds
             threshold = 3,              -- Animate only if cursor moves more than this many lines
-	    max_threshold = 500         -- If you move more than this many lines, don't animate
+            max_threshold = 500         -- If you move more than this many lines, don't animate
             disable_float_win = false,  -- Disable in floating windows
             enabled_filetypes = nil,    -- Enable only for specific file types, e.g., { "lua", "vim" }
             disabled_filetypes = nil,   -- Disable for these file types, ignored if enabled_filetypes is set. e.g., { "TelescopePrompt", "NvimTree" }

--- a/lua/smoothcursor/callbacks/default.lua
+++ b/lua/smoothcursor/callbacks/default.lua
@@ -14,14 +14,15 @@ local function sc_default()
   if buffer['prev'] == nil then
     buffer['prev'] = buffer['.']
   end
-  buffer['diff'] = buffer['prev'] - buffer['.']
-  buffer['diff'] = math.min(buffer['diff'], vim.fn.winheight(0) * 2)
+  local absolute_diff = math.abs(buffer['prev'] - buffer['.'])
+  local relative_diff = math.min(absolute_diff, vim.fn.winheight(0) * 2)
   buffer['w0'] = vim.fn.line('w0')
   buffer['w$'] = vim.fn.line('w$')
 
-  local value = math.abs(buffer['diff'])
-
-  if value > config.value.threshold and value <= config.value.max_threshold then
+  if
+    relative_diff > config.value.threshold
+    and (config.value.max_threshold == nil or absolute_diff <= config.value.max_threshold)
+  then
     local counter = 1
     callback.sc_timer:post(function()
       buffer['.'] = vim.fn.line('.')

--- a/lua/smoothcursor/callbacks/default.lua
+++ b/lua/smoothcursor/callbacks/default.lua
@@ -19,7 +19,9 @@ local function sc_default()
   buffer['w0'] = vim.fn.line('w0')
   buffer['w$'] = vim.fn.line('w$')
 
-  if math.abs(buffer['diff']) > config.value.threshold then
+  local value = math.abs(buffer['diff'])
+
+  if value > config.value.threshold and value < config.value.max_threshold then
     local counter = 1
     callback.sc_timer:post(function()
       buffer['.'] = vim.fn.line('.')

--- a/lua/smoothcursor/callbacks/default.lua
+++ b/lua/smoothcursor/callbacks/default.lua
@@ -21,7 +21,7 @@ local function sc_default()
 
   local value = math.abs(buffer['diff'])
 
-  if value > config.value.threshold and value < config.value.max_threshold then
+  if value > config.value.threshold and value <= config.value.max_threshold then
     local counter = 1
     callback.sc_timer:post(function()
       buffer['.'] = vim.fn.line('.')

--- a/lua/smoothcursor/callbacks/exp.lua
+++ b/lua/smoothcursor/callbacks/exp.lua
@@ -13,14 +13,15 @@ local function sc_exp()
   if buffer['prev'] == nil then
     buffer['prev'] = buffer['.']
   end
-  buffer['diff'] = buffer['prev'] - buffer['.']
-  buffer['diff'] = math.min(buffer['diff'], vim.fn.winheight(0) * 2)
+  local absolute_diff = math.abs(buffer['prev'] - buffer['.'])
+  local relative_diff = math.min(absolute_diff, vim.fn.winheight(0) * 2)
   buffer['w0'] = vim.fn.line('w0')
   buffer['w$'] = vim.fn.line('w$')
 
-  local value = math.abs(buffer['diff'])
-
-  if value > config.value.threshold and value <= config.value.max_threshold then
+  if
+    relative_diff > config.value.threshold
+    and (config.value.max_threshold == nil or absolute_diff <= config.value.max_threshold)
+  then
     local counter = 1
     callback.sc_timer:post(function()
       buffer['.'] = vim.fn.line('.')

--- a/lua/smoothcursor/callbacks/exp.lua
+++ b/lua/smoothcursor/callbacks/exp.lua
@@ -17,7 +17,10 @@ local function sc_exp()
   buffer['diff'] = math.min(buffer['diff'], vim.fn.winheight(0) * 2)
   buffer['w0'] = vim.fn.line('w0')
   buffer['w$'] = vim.fn.line('w$')
-  if math.abs(buffer['diff']) > config.value.threshold then
+
+  local value = math.abs(buffer['diff'])
+
+  if value > config.value.threshold and value < config.value.max_threshold then
     local counter = 1
     callback.sc_timer:post(function()
       buffer['.'] = vim.fn.line('.')

--- a/lua/smoothcursor/callbacks/exp.lua
+++ b/lua/smoothcursor/callbacks/exp.lua
@@ -20,7 +20,7 @@ local function sc_exp()
 
   local value = math.abs(buffer['diff'])
 
-  if value > config.value.threshold and value < config.value.max_threshold then
+  if value > config.value.threshold and value <= config.value.max_threshold then
     local counter = 1
     callback.sc_timer:post(function()
       buffer['.'] = vim.fn.line('.')

--- a/lua/smoothcursor/callbacks/matrix.lua
+++ b/lua/smoothcursor/callbacks/matrix.lua
@@ -17,7 +17,13 @@ local function sc_matrix()
   buffer['diff'] = math.min(buffer['diff'], vim.fn.winheight(0) * 2)
   buffer['w0'] = vim.fn.line('w0')
   buffer['w$'] = vim.fn.line('w$')
-  if math.abs(buffer['diff']) > config.value.threshold or config.value.matrix.unstop then
+
+  local value = math.abs(buffer['diff'])
+
+  if
+    config.value.matrix.unstop
+    or (value > config.value.threshold and value < config.value.max_threshold)
+  then
     local counter = 1
     callback.sc_timer:post(function()
       buffer['.'] = vim.fn.line('.')

--- a/lua/smoothcursor/callbacks/matrix.lua
+++ b/lua/smoothcursor/callbacks/matrix.lua
@@ -22,7 +22,7 @@ local function sc_matrix()
 
   if
     config.value.matrix.unstop
-    or (value > config.value.threshold and value < config.value.max_threshold)
+    or (value > config.value.threshold and value <= config.value.max_threshold)
   then
     local counter = 1
     callback.sc_timer:post(function()

--- a/lua/smoothcursor/callbacks/matrix.lua
+++ b/lua/smoothcursor/callbacks/matrix.lua
@@ -13,16 +13,15 @@ local function sc_matrix()
   if buffer['prev'] == nil then
     buffer['prev'] = buffer['.']
   end
-  buffer['diff'] = buffer['prev'] - buffer['.']
-  buffer['diff'] = math.min(buffer['diff'], vim.fn.winheight(0) * 2)
+  local absolute_diff = math.abs(buffer['prev'] - buffer['.'])
+  local relative_diff = math.min(absolute_diff, vim.fn.winheight(0) * 2)
   buffer['w0'] = vim.fn.line('w0')
   buffer['w$'] = vim.fn.line('w$')
 
-  local value = math.abs(buffer['diff'])
-
   if
     config.value.matrix.unstop
-    or (value > config.value.threshold and value <= config.value.max_threshold)
+    or relative_diff > config.value.threshold
+      and (config.value.max_threshold == nil or absolute_diff <= config.value.max_threshold)
   then
     local counter = 1
     callback.sc_timer:post(function()

--- a/lua/smoothcursor/config.lua
+++ b/lua/smoothcursor/config.lua
@@ -54,7 +54,7 @@ return {
     timeout = 3000,
     type = 'default',
     threshold = 3,
-    max_threshold = 500,
+    max_threshold = nil,
     speed = 25,
     autostart = true,
     priority = 10,

--- a/lua/smoothcursor/config.lua
+++ b/lua/smoothcursor/config.lua
@@ -54,6 +54,7 @@ return {
     timeout = 3000,
     type = 'default',
     threshold = 3,
+    max_threshold = 500,
     speed = 25,
     autostart = true,
     priority = 10,

--- a/lua/smoothcursor/init.lua
+++ b/lua/smoothcursor/init.lua
@@ -51,6 +51,7 @@ local config = require('smoothcursor.config')
 ---@field timeout integer
 ---@field type string
 ---@field threshold integer
+---@field max_threshold integer
 ---@field speed integer
 ---@field autostart boolean
 ---@field priority integer


### PR DESCRIPTION
I noticed quite some slowdown when dealing with large files and quickly jumping to the end (G) or the beginning (gg). I figured this was SmoothCursor.nvim's fault.

I added a setting to set a max threshold. If you move more than this amount of lines, there will be no animation. Tried it out in practice, after that there was no more slowdown anymore ^^